### PR TITLE
add option to map to continue on errors and run all async operations

### DIFF
--- a/lib/PeerRPCClient.js
+++ b/lib/PeerRPCClient.js
@@ -110,31 +110,7 @@ class PeerRPCClient extends PeerRPC {
           return
         }
 
-        if (!dests.length) {
-          return cb(null, [])
-        }
-
-        const limit = opts.limit || 0
-        if (limit) {
-          dests = _.slice(_.shuffle(dests), 0, limit)
-        }
-
-        async.map(dests, (dest, next) => {
-          this.transport(dest, this.getTransportOpts(opts))
-            .request(key, payload, this.getRequestOpts(opts), next)
-        }, cb)
-      }
-    )
-  }
-
-  mapAll (key, payload, opts = {}, cb) {
-    this.link.lookup(
-      key, {},
-      (err, dests) => {
-        if (err) {
-          cb(err)
-          return
-        }
+        const continueOnErrors = opts.continueOnErrors || false
 
         if (!dests.length) {
           return cb(null, [])
@@ -154,7 +130,15 @@ class PeerRPCClient extends PeerRPC {
         async.map(newDests, (dest, next) => {
           this.transport(dest, this.getTransportOpts(opts))
             .request(key, payload, this.getRequestOpts(opts), (err, data) => {
-              if (err) { next(null, err) } else { next(err, data) }
+              if (continueOnErrors) {
+                if (err) {
+                  next(null, err)
+                } else {
+                  next(err, data)
+                }
+              } else {
+                next(err, data)
+              }
             })
         }, cb)
       }

--- a/lib/PeerRPCClient.js
+++ b/lib/PeerRPCClient.js
@@ -127,6 +127,40 @@ class PeerRPCClient extends PeerRPC {
     )
   }
 
+  mapAll (key, payload, opts = {}, cb) {
+    this.link.lookup(
+      key, {},
+      (err, dests) => {
+        if (err) {
+          cb(err)
+          return
+        }
+
+        if (!dests.length) {
+          return cb(null, [])
+        }
+
+        const limit = opts.limit || 0
+        if (limit) {
+          dests = _.slice(_.shuffle(dests), 0, limit)
+        }
+
+        const excludeDests = opts.excludeDests || false
+        let newDests = dests
+        if (excludeDests) {
+          newDests = dests.filter(dest => !excludeDests.includes(dest))
+        }
+
+        async.map(newDests, (dest, next) => {
+          this.transport(dest, this.getTransportOpts(opts))
+            .request(key, payload, this.getRequestOpts(opts), (err, data) => {
+              if (err) { next(null, err) } else { next(err, data) }
+            })
+        }, cb)
+      }
+    )
+  }
+
   _stop () {
     super._stop()
     this.tpool.stop()


### PR DESCRIPTION
adds `continueOnErrors` an option to `map`, to continue on errors.
adds `excludeDests` an option to `map`, to exclude a node.

`continueOnErrors` use case:   In implementing data synchronization, we want to update as many nodes as possible, even if some nodes return an error.      For example, if a node is stopped for maintenance,  _Grenache_ will still try to connect to that node for about a minute.    In this scenario, `map` will stop processing and return an `Error`.    However, in synchronization, a recently stopped node is not an error at all as it will automatically sync when it starts back up.

`continueOnErrors` use case, when a node is message it's own service, we want to exclude itself.

NOTE:  `map` utilizes a non standard way to handle errors by returning an `Error` object as the result.  To handle errors, you must check each result to see if it is an `instance of Error` before using it.